### PR TITLE
Document APIs in ByteString/Text modules

### DIFF
--- a/src/System/Process/ByteString.hs
+++ b/src/System/Process/ByteString.hs
@@ -18,8 +18,15 @@ instance ListLikeProcessIO ByteString Word8 where
     readChunks h = (: []) <$> hGetContents h
 
 -- | Specialized version for backwards compatibility.
-readProcessWithExitCode :: FilePath -> [String] -> ByteString -> IO (ExitCode, ByteString, ByteString)
+readProcessWithExitCode
+    :: FilePath                              -- ^ command to run
+    -> [String]                              -- ^ any arguments
+    -> ByteString                            -- ^ standard input
+    -> IO (ExitCode, ByteString, ByteString) -- ^ exitcode, stdout, stderr
 readProcessWithExitCode = System.Process.Common.readProcessWithExitCode
 
-readCreateProcessWithExitCode :: CreateProcess -> ByteString -> IO (ExitCode, ByteString, ByteString)
+readCreateProcessWithExitCode
+    :: CreateProcess                         -- ^ command and arguments to run
+    -> ByteString                            -- ^ standard input
+    -> IO (ExitCode, ByteString, ByteString) -- ^ exitcode, stdout, stderr
 readCreateProcessWithExitCode = System.Process.Common.readCreateProcessWithExitCode

--- a/src/System/Process/ByteString/Lazy.hs
+++ b/src/System/Process/ByteString/Lazy.hs
@@ -19,8 +19,15 @@ instance ListLikeProcessIO ByteString Word8 where
     readChunks h = (map (fromChunks . (: [])) . toChunks) <$> hGetContents h
 
 -- | Specialized version for backwards compatibility.
-readProcessWithExitCode :: FilePath -> [String] -> ByteString -> IO (ExitCode, ByteString, ByteString)
+readProcessWithExitCode
+    :: FilePath                              -- ^ command to run
+    -> [String]                              -- ^ any arguments
+    -> ByteString                            -- ^ standard input
+    -> IO (ExitCode, ByteString, ByteString) -- ^ exitcode, stdout, stderr
 readProcessWithExitCode = System.Process.Common.readProcessWithExitCode
 
-readCreateProcessWithExitCode :: CreateProcess -> ByteString -> IO (ExitCode, ByteString, ByteString)
+readCreateProcessWithExitCode
+    :: CreateProcess                         -- ^ command and arguments to run
+    -> ByteString                            -- ^ standard input
+    -> IO (ExitCode, ByteString, ByteString) -- ^ exitcode, stdout, stderr
 readCreateProcessWithExitCode = System.Process.Common.readCreateProcessWithExitCode

--- a/src/System/Process/Text.hs
+++ b/src/System/Process/Text.hs
@@ -17,8 +17,15 @@ instance ListLikeProcessIO Text Char where
     readChunks h = (: []) <$> hGetContents h
 
 -- | Specialized version for backwards compatibility.
-readProcessWithExitCode :: FilePath -> [String] -> Text -> IO (ExitCode, Text, Text)
+readProcessWithExitCode
+    :: FilePath                  -- ^ command to run
+    -> [String]                  -- ^ any arguments
+    -> Text                      -- ^ standard input
+    -> IO (ExitCode, Text, Text) -- ^ exitcode, stdout, stderr
 readProcessWithExitCode = System.Process.Common.readProcessWithExitCode
 
-readCreateProcessWithExitCode :: CreateProcess -> Text -> IO (ExitCode, Text, Text)
+readCreateProcessWithExitCode
+    :: CreateProcess             -- ^ command and arguments to run
+    -> Text                      -- ^ standard input
+    -> IO (ExitCode, Text, Text) -- ^ exitcode, stdout, stderr
 readCreateProcessWithExitCode = System.Process.Common.readCreateProcessWithExitCode

--- a/src/System/Process/Text/Lazy.hs
+++ b/src/System/Process/Text/Lazy.hs
@@ -18,8 +18,15 @@ instance ListLikeProcessIO Text Char where
     readChunks h = (map (fromChunks . (: [])) . toChunks) <$> hGetContents h
 
 -- | Specialized version for backwards compatibility.
-readProcessWithExitCode :: FilePath -> [String] -> Text -> IO (ExitCode, Text, Text)
+readProcessWithExitCode
+    :: FilePath                  -- ^ command to run
+    -> [String]                  -- ^ any arguments
+    -> Text                      -- ^ standard input
+    -> IO (ExitCode, Text, Text) -- ^ exitcode, stdout, stderr
 readProcessWithExitCode = System.Process.Common.readProcessWithExitCode
 
-readCreateProcessWithExitCode :: CreateProcess -> Text -> IO (ExitCode, Text, Text)
+readCreateProcessWithExitCode
+    :: CreateProcess             -- ^ command and arguments to run
+    -> Text                      -- ^ standard input
+    -> IO (ExitCode, Text, Text) -- ^ exitcode, stdout, stderr
 readCreateProcessWithExitCode = System.Process.Common.readCreateProcessWithExitCode


### PR DESCRIPTION
I'm doing this because I landed on the package in hackage, went to the
module I needed (Text), didn't understand one of the arguments, read the
source, then had to go to common to find what the argument was. I
figured it would be nice if all the modules the user was likely to use
were documented equally.