### PR TITLE
Consolidate orphan Generic ExitCode instance with generic-deriving

### DIFF
--- a/process-extras.cabal
+++ b/process-extras.cabal
@@ -44,4 +44,5 @@ Library
     process,
     bytestring,
     text,
-    deepseq >= 1.1
+    deepseq >= 1.1,
+    generic-deriving >= 1.10

--- a/src/System/Process/Common.hs
+++ b/src/System/Process/Common.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module System.Process.Common
@@ -25,6 +23,7 @@ import Control.Monad
 import Data.ListLike (null)
 import Data.ListLike.IO (ListLikeIO, hGetContents, hPutStr)
 import Data.Monoid ((<>))
+import Generics.Deriving.Instances ()
 import GHC.IO.Exception (IOErrorType(ResourceVanished), IOException(ioe_type))
 import Prelude hiding (null)
 import System.Exit (ExitCode(..))
@@ -36,12 +35,6 @@ import Utils (forkWait)
 #if __GLASGOW_HASKELL__ <= 709
 import Control.Applicative (pure, (<$>), (<*>))
 import Data.Monoid (Monoid(mempty, mappend))
-#else
-import GHC.Generics
-
-#if __GLASGOW_HASKELL__ <= 710
-deriving instance Generic ExitCode
-#endif
 #endif
 
 #if !MIN_VERSION_deepseq(1,4,2)


### PR DESCRIPTION
`generic-deriving`'s `Generic.Deriving.Instances` is the canonical home for orphan `Generic` instances (à la `base-orphans`), and `generic-deriving-1.10` just added an orphan `Generic ExitCode` instance. This PR consolidates the orphan `Generic ExitCode` instance in `process-extras` with the one in `generic-deriving` to avoid instance conflicts.