### PR TITLE
Tests.hs Use printf instead of echo -n for portability

### DIFF
--- a/Tests.hs
+++ b/Tests.hs
@@ -37,7 +37,7 @@ dir :: FilePath
 dir = "/usr/share/doc/cron"
 
 cmd :: CreateProcess
-cmd = shell "echo a; echo b 1>&2; echo -n c"
+cmd = shell "echo a; echo b 1>&2; printf c"
 
 omitProcessHandle :: [Chunk a] -> [Chunk a]
 omitProcessHandle [] = []


### PR DESCRIPTION
Fixes #10 

Should also improve portability on systems that don't have an echo that recognizes -n, which is common outside of linux.